### PR TITLE
Feature/add multiple authorizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Secure single node NiFi Registry instance with LDAP:
         /loginIdentityProviders/provider/property[@name="Url"]: ldap://hostname:port
         /loginIdentityProviders/provider/property[@name="User Search Base"]: OU=people,DC=example,DC=com
         /loginIdentityProviders/provider/property[@name="User Search Filter"]: sAMAccountName={0}
+      authorizers_identifiers:
+        - file-user-group-provider
+        - ldap-user-group-provider
+        - composite-user-group-provider
       authorizers:
         /authorizers/userGroupProvider/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
         /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people,dc=example,dc=com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ authorizers:
   /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_registry_config_dirs.external_config }}/authorizations.xml"
 
 # Specify idenfiers of different authorizers
-authorizers_identifiers: []
+authorizers_identifiers: {}
 
 providers:
   /providers/flowPersistenceProvider/property[@name="Flow Storage Directory"]: "{{ nifi_registry_config_dirs.external_config }}/flow_storage"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,9 @@ authorizers:
   /authorizers/userGroupProvider/property[@name="Users File"]: "{{ nifi_registry_config_dirs.external_config }}/users.xml"
   /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_registry_config_dirs.external_config }}/authorizations.xml"
 
+# Specify idenfiers of different authorizers
+authorizers_identifiers: []
+
 providers:
   /providers/flowPersistenceProvider/property[@name="Flow Storage Directory"]: "{{ nifi_registry_config_dirs.external_config }}/flow_storage"
   /providers/extensionBundlePersistenceProvider/property[@name="Extension Bundle Storage Directory"]: "{{ nifi_registry_config_dirs.external_config }}/extension_bundles"

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -47,15 +47,16 @@
     - name: Uncomment block in authorizers.xml
       replace:
         path: "{{ nifi_registry_config_dirs.home }}/conf/authorizers.xml"
-        regexp: "^.*To enable the {{ authorizers['/authorizers/userGroupProvider/identifier'] }}.*$"
+        regexp: "^.*To enable the {{ item }}.*$"
         replace: ""
+      with_items: "{{ authorizers_identifiers }}"
     - name: Update properties in authorizers.xml
       xml:
         path: "{{ nifi_registry_config_dirs.home }}/conf/authorizers.xml"
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
       with_dict: "{{ authorizers }}"
-  when: authorizers['/authorizers/userGroupProvider/identifier'] | length
+  when: authorizers_identifiers | length
 
 - name: Update providers.xml
   xml:


### PR DESCRIPTION
According to [authorizers.xml XSD schema](https://github.com/apache/nifi/blob/dd620680b1e3e053acfc7c1b1e3f000de57351c8/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-authorizer/src/main/xsd/authorizers.xsd) there could be multiple providers. Providers could be specified as list in new variable. Default is not to use authorizers.