### PR TITLE
Make templating of key=value properties idempotent

### DIFF
--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -10,14 +10,14 @@
   lineinfile:
     path: "{{ nifi_registry_config_dirs.home }}/conf/nifi-registry.properties"
     line: "{{ item.key }}={{ item.value }}"
-    regexp: "^{{ item.key }}"
+    regexp: "^{{ item.key }}="
   with_dict: "{{ nifi_registry_properties }}"
 
 - name: Update bootstrap.conf
   lineinfile:
     path: "{{ nifi_registry_config_dirs.home }}/conf/bootstrap.conf"
     line: "{{ item.key }}={{ item.value }}"
-    regexp: "^{{ item.key }}"
+    regexp: "^{{ item.key }}="
   with_dict: "{{ bootstrap }}"
 
 - name: Update logback.xml


### PR DESCRIPTION
When this role is run multiple times, properties starting with same string like _nifi.registry.security.truststore_ while there are properties _nifi.registry.security.truststoreType_ and also _nifi.registry.security.truststorePasswd_ , the _nifi.registry.security.truststore_ is inserted multiple times. In order to eliminate this behaviour and make this role idempotent, the regular expressions should also match **=**, at the end of property name.
