### PR TITLE
Support nifi_registry versions > 0.8.0

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,15 @@
 ---
-- name: Download NiFi Registry binary
+- name: Download NiFi Registry binary > 0.8.0
+  get_url:
+    url: "{{ download_mirror_uri }}/nifi/{{ nifi_registry_version }}/nifi-registry-{{ nifi_registry_version }}-bin.tar.gz"
+    dest: "/tmp/nifi-registry-{{ nifi_registry_version }}-bin.tar.gz"
+  when: nifi_registry_version is version('0.8.0', '>')
+
+- name: Download NiFi Registry binary <= 0.8.0
   get_url:
     url: "{{ download_mirror_uri }}/nifi/nifi-registry/nifi-registry-{{ nifi_registry_version }}/nifi-registry-{{ nifi_registry_version }}-bin.tar.gz"
     dest: "/tmp/nifi-registry-{{ nifi_registry_version }}-bin.tar.gz"
+  when: nifi_registry_version is version('0.8.0', '<=')
 
 - name: Unpack NiFi Registry binary
   unarchive:


### PR DESCRIPTION
After nifi-registry 0.8.0 the versions are fully merged into the nifi releases and these version numbers are kept
in sync. After 0.8.0 the next version is 1.14.0. The download locations have also been altered as of version 1.14.0.